### PR TITLE
Minimal 'no results' page and empty query handling (avoiding flashing)

### DIFF
--- a/src/components/EmptyResults.js
+++ b/src/components/EmptyResults.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default React.createClass({
+  render: function () {
+    return (
+      <div className="empty-results">
+        <h3>No results</h3>
+        <blockquote>
+          <p>Try searching something like <i>cd</i></p>
+        </blockquote>
+      </div>
+    );
+  },
+
+});

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -7,6 +7,8 @@ import { Page } from '../actions/Page';
 import CommandStore from '../stores/Command';
 import PageStore from '../stores/Page';
 
+import EmptyResults from './EmptyResults';
+
 export default React.createClass({
 
   componentDidMount: function () {
@@ -23,8 +25,11 @@ export default React.createClass({
 
   render: function () {
     let markup = marked(this.state.body);
+    let results = markup ? <span dangerouslySetInnerHTML={{__html: markup }} /> : <EmptyResults />
     return (
-      <div id="page" dangerouslySetInnerHTML={{__html: markup }} />
+      <div id="page">
+        {results}
+      </div>
     );
   },
 
@@ -32,6 +37,8 @@ export default React.createClass({
     let cmd = CommandStore.getCurrentCommand().pop();
     PageStore.get(cmd).then( page => {
       this.setState({ body: page });
+    }).catch( err => {
+      this.setState({ body: '' });
     });
   }
 

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -51,7 +51,7 @@ export default React.createClass({
 
   _handleEnter: function (event) {
     const query = this.cleanQuery(this.state.query);
-    if (event.keyCode === ENTER_KEY_CODE && query) {
+    if (event.keyCode === ENTER_KEY_CODE) {
       event.preventDefault();
       this.history.push({ pathname: query });
     }

--- a/styles/page.sass
+++ b/styles/page.sass
@@ -31,6 +31,10 @@
       padding: 0.5em 0.55em
       line-height: 1.1
 
+  .empty-results
+    h3
+      margin: 0 0.23em
+
   // Landscape stlyes
   @media only screen and (orientation: landscape)
     margin-top: 5em


### PR DESCRIPTION
Hey! I've added two little things to `tldr.jsx`:

* Allowed an empty query to be "valid", to avoid the screen flash that occurred when the form was submitted:

![flash](https://cloud.githubusercontent.com/assets/692077/12074889/0121a10c-b14c-11e5-814d-4bad3588b74a.gif)

* Added a `no results` notice, because when I first tested the site I didn't understand what was going on without feedback (I wrote some nonsense on the search bar) it looks like this:

![image](https://cloud.githubusercontent.com/assets/692077/12074891/33e38358-b14c-11e5-81bd-f8daf28b85d4.png)


I didn't put _that_ much time on the PR (the empty notice is pretty weak).
Feel free to close the PR and rewrite it if you want, I'm satisfied if I at least gave you some ideas :)