### PR TITLE
Update not found page to fix command request link.

### DIFF
--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -25,7 +25,7 @@ export default () => (
 {Cr}
     ### How can I help?
 {Cr}
-    Take a look at the open <Link href="https://github.com/tldr-pages/tldr/issues?q=is%3Aopen+is%3Aissue+label%3Acommand" text="Command Requests" /> to throw a jab at things people need, or maybe join in on any of the open <Link href="https://github.com/tldr-pages/tldr/pulls" text="command proposals" />.
+    Take a look at the open <Link href="https://github.com/tldr-pages/tldr/issues?q=is%3Aissue+is%3Aopen+label%3A%22new+command%22" text="Command Requests" /> to throw a jab at things people need, or maybe join in on any of the open <Link href="https://github.com/tldr-pages/tldr/pulls" text="command proposals" />.
 {Cr}
     If the command you want hasn't been proposed yet, feel encouraged to submit a proposal yourself! 😉 &mdash; <Link href="https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md" text="Start here" />
 {Cr}


### PR DESCRIPTION
The new command label seems to have changed recently. This commit fixes the broken link.