### PR TITLE
Set search to autofocus

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -34,6 +34,7 @@ export default ({navigate, version}: NavigateProps) => (
       </section>
       <section className="search">
         <input
+          autofocus
           tabIndex="100"
           type="text"
           onChange={ ({target: {value}}) => navigate(value) }


### PR DESCRIPTION
Hey there,

Thanks for making this app! Super handy for quick searches 👍 

One little thing I noticed that would help is if the search bar autofocused on page load, so I could just type your URL in my browserm then without leaving the keyboard, I could type my query and be done. Saves reaching for the mouse 🤷‍♂️ 

Note: I didn't test this change; it just adds `autofocus` to the search input, and I'm fairly positive that's all this will take, so I made it inline on GitHub.