### PR TITLE
Correct 'autoFocus' attribute name

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -34,7 +34,7 @@ export default ({ navigate, version }: NavigateProps) => (
       </section>
       <section className="search">
         <input
-          autofocus
+          autoFocus
           tabIndex="100"
           type="text"
           onChange={({ target: { value } }) => navigate(value)}


### PR DESCRIPTION
It should be `autoFocus`.

See https://gitter.im/tldr-pages/tldr?at=60208c2055359c58bf2bb253 for details.